### PR TITLE
GPU version of HP2P

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,6 @@ AC_PREREQ([2.63])
 AC_INIT([HP2P], [4.0], [laurent.nguyen@cea.fr])
 AM_INIT_AUTOMAKE([-Wall])
 AC_CONFIG_SRCDIR([src/])
-AC_CONFIG_HEADERS([config.h])
 
 # use the C++ compiler for the following checks
 AC_LANG([C++])
@@ -45,6 +44,35 @@ AC_CHECK_FUNCS([getopt])
 AC_CHECK_FUNCS([MPI_Init MPI_Finalize])
 #AC_CHECK_FUNCS([MPI_File_open MPI_File_close])
 
+# Checks for CUDA
+AC_ARG_ENABLE([cuda],
+              [AS_HELP_STRING([--enable-cuda],
+                              [Enable CUDA benchmarks (default is no).])
+              ],
+              [],
+              [enable_cuda=no])
+
+AC_ARG_WITH([cuda],
+            [AS_HELP_STRING([--with-cuda=@<:@CUDA installation path@:>@],
+                            [Provide path to CUDA installation])
+            ],
+            [AS_CASE([$with_cuda],
+                     [yes|no], [],
+                     [CPPFLAGS="-I$with_cuda/include $CPPFLAGS"
+                      LDFLAGS="-L$with_cuda/lib64 -Wl,-rpath=$with_cuda/lib64 -L$with_cuda/lib -Wl,-rpath=$with_cuda/lib $LDFLAGS"])
+            ])
+AS_CASE([$enable_cuda],
+	[yes], [build_cuda=yes])
+
+AS_IF([test "x$build_cuda" = xyes], [
+       AC_SEARCH_LIBS([cuPointerGetAttribute], [cuda], [],
+                      [AC_MSG_ERROR([cannot link with -lcuda])])
+       AC_SEARCH_LIBS([cudaFree], [cudart], [],
+                      [AC_MSG_ERROR([cannot link with -lcudart])])
+       AC_CHECK_HEADERS([cuda.h], [],
+                        [AC_MSG_ERROR([cannot include cuda.h])])
+       AC_DEFINE([_ENABLE_CUDA_], [1], [Enable CUDA])
+       ])
 
 AC_CONFIG_FILES([Makefile
 	src/Makefile])

--- a/src/hp2p.h
+++ b/src/hp2p.h
@@ -31,6 +31,10 @@
 #include <time.h>
 
 #include "mpi.h"
+#ifdef _ENABLE_CUDA_
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
 
 #define MAXCHARFILE 4096
 
@@ -67,8 +71,10 @@ typedef struct
 {
   int root;
   int rank;
+  int local_rank;
   int nproc;
   MPI_Comm comm;
+  MPI_Comm local_comm;
   char localhost[MPI_MAX_PROCESSOR_NAME];
   char *hostlist;
 } hp2p_mpi_config;

--- a/src/hp2p_mpi.c
+++ b/src/hp2p_mpi.c
@@ -29,8 +29,18 @@ int hp2p_mpi_init(int *argc, char ***argv, hp2p_mpi_config *mpi_conf)
   MPI_Init(argc, argv);
   MPI_Comm_size(mpi_conf->comm, &mpi_conf->nproc);
   MPI_Comm_rank(mpi_conf->comm, &mpi_conf->rank);
+
+#ifdef _ENABLE_CUDA_
+  MPI_Comm_split_type(mpi_conf->comm, MPI_COMM_TYPE_SHARED, mpi_conf->rank, MPI_INFO_NULL, &mpi_conf->local_comm);
+  MPI_Comm_rank(mpi_conf->local_comm, &mpi_conf->local_rank);
+  cudaSetDevice(mpi_conf->local_rank);
+#endif
+  
   mpi_conf->root = 0;
   MPI_Get_processor_name(mpi_conf->localhost, &namelen);
+#ifdef _ENABLE_CUDA_
+  sprintf(mpi_conf->localhost, "%s:%d", mpi_conf->localhost, mpi_conf->local_rank);
+#endif
   mpi_conf->hostlist = malloc(mpi_conf->nproc*MPI_MAX_PROCESSOR_NAME*sizeof(char));
   MPI_Allgather(mpi_conf->localhost, MPI_MAX_PROCESSOR_NAME, MPI_CHAR,
 		mpi_conf->hostlist, MPI_MAX_PROCESSOR_NAME, MPI_CHAR, mpi_conf->comm);
@@ -42,6 +52,9 @@ int hp2p_mpi_get_hostname(hp2p_mpi_config *mpi_conf, int anonymize)
   char rank_str[MPI_MAX_PROCESSOR_NAME] = "";
 
   sprintf(rank_str, "rank_%d", mpi_conf->rank);
+#ifdef _ENABLE_CUDA_
+  sprintf(rank_str, "%s:%d", mpi_conf->localhost, mpi_conf->local_rank);
+#endif
   
   if(anonymize == 1)
     {


### PR DESCRIPTION
- update of configure.ac to use `--enable-cuda` and `--with-cuda` flags in order to compile HP2P for NVIDIA GPU using CUDA
- update of `hp2p.h` to add CUDA headers and additional elements in MPI struct
- update of `hp2p_mpi.c` to append GPU ID to hostname
- update of `hp2p.c` to perform communication using buffers located on GPU